### PR TITLE
Coreymccourt/ch63811/refactor and migrate validation and auto

### DIFF
--- a/lib/shared/utils.js
+++ b/lib/shared/utils.js
@@ -48,9 +48,20 @@ function timecodeToMicroseconds(timecode, fps) {
 }
 
 function extractStyling(text) {
-  let unformattedText = text.replace(/(?<!^)<br>/, '\n'); // <br> anywhere except front of line
-  unformattedText = unformattedText.replace(/{[^}]*}/g, ' ').replace(/\s\s+/, ' '); // {...}
-  unformattedText = unformattedText.replace(/<[^>]*>/g, ''); // <....>
+  let unformattedText = '';
+  if (text.search(/<br>/) && !text.startsWith('<br>')) {
+    unformattedText = text.replace(/<br>/, '\n');
+  }
+  const formattingTags = unformattedText.match(/<[^>]*>|{[^}]*}/g);
+  if (formattingTags && formattingTags.length) {
+    formattingTags.forEach(tag => {
+      if (tag.search(/{[^}]*}/) > -1) {
+        unformattedText = unformattedText.replace(tag, ' ').replace(/\s\s+/, ' ');
+      } else {
+        unformattedText = unformattedText.replace(tag, '');
+      }
+    });
+  }
 
   return unformattedText.trim();
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subtitle-converter",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Convert subtitles from one format to another",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`/(?<!^)<br>/` was breaking  because negative look behind is only supported on some browsers.