### PR TITLE
Srt parse bug fix

### DIFF
--- a/lib/parsers/srtEntries.js
+++ b/lib/parsers/srtEntries.js
@@ -19,16 +19,16 @@ function standardizeTimestamp(timestamp) {
 }
 
 function pushInvalidEntry(acc, cur, options, invalidTimecodeFound, invalidIndexFound) {
-  const invalidEntry = {
-    id: cur.match(potentialIndexRegex) ? cur.match(potentialIndexRegex)[0] : undefined,
-    timecode: cur.match(potentialTimecodeRegex)[0],
-    text: cur.split(potentialTimecodeRegex)[1], // Split with timecode, 0 postion will be the 'id' or empty string
-  };
-
   acc.status.success = false;
+
+  const id = cur.match(potentialIndexRegex) ? cur.match(potentialIndexRegex)[0] : undefined;
+  const timecode = cur.match(potentialTimecodeRegex)[0];
+  const text = cur.split(potentialTimecodeRegex)[1]; // Split with timecode, 0 postion will be the 'id' or empty string
+  const invalidEntry = { id, timecode, text };
+
   if (options.invalidEntries) acc.status.invalidEntries.push(invalidEntry);
-  if (options.invalidIndices && invalidIndexFound) acc.status.invalidIndices.push(invalidEntry.id);
-  if (options.invalidTimecodes && invalidTimecodeFound) acc.status.invalidTimecodes.push(invalidEntry.timecode);
+  if (options.invalidIndices && invalidIndexFound) acc.status.invalidIndices.push({ id });
+  if (options.invalidTimecodes && invalidTimecodeFound) acc.status.invalidTimecodes.push({ id, timecode });
   return acc;
 }
 

--- a/lib/parsers/srtEntriesRegex.js
+++ b/lib/parsers/srtEntriesRegex.js
@@ -13,7 +13,7 @@ const validSeconds = '[0-5]\\d';
 const validMilliseconds = '\\d{3}';
 const any = '[^\\n\\d]+?'; // Any character but digit or newline
 const validTimestamp = `${validHours}${any}${validMinutes}${any}${validSeconds}${any}${validMilliseconds}`;
-const validTimecode = `${validTimestamp}[^\\n\\d]+?${validTimestamp}(?=(\\D|$))`;
+const validTimecode = `${validTimestamp}[^\\n\\d]+?${validTimestamp}(?=(\\n|$))`;
 const textOfEntry = '[^]+';
 
 // Capturing Groups for entries

--- a/lib/parsers/srtEntriesRegex.js
+++ b/lib/parsers/srtEntriesRegex.js
@@ -13,7 +13,7 @@ const validSeconds = '[0-5]\\d';
 const validMilliseconds = '\\d{3}';
 const any = '[^\\n\\d]+?'; // Any character but digit or newline
 const validTimestamp = `${validHours}${any}${validMinutes}${any}${validSeconds}${any}${validMilliseconds}`;
-const validTimecode = `${validTimestamp}[^\\n\\d]+?${validTimestamp}[^\\n\\d]*?`;
+const validTimecode = `${validTimestamp}[^\\n\\d]+?${validTimestamp}(?=(\\D|$))`;
 const textOfEntry = '[^]+';
 
 // Capturing Groups for entries

--- a/lib/tests/mocks/badTimecodeSyntax.js
+++ b/lib/tests/mocks/badTimecodeSyntax.js
@@ -6,8 +6,12 @@ const badTimecodeSyntax = `00:00:05,446 --> 00:00:10,817
 <i>Can’t see original dreams</i>
 
 3
-02:00:21,446 --> 02:22:10,873
+02:00:21,446 --> 02:22:10,873k33
 <i>Something else in this</i>
+
+k
+02:00:21,446 --> 02:22:10,8733333
+<i>Cheese is my middle name</i>
 
 `;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "subtitle-converter",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subtitle-converter",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Convert subtitles from one format to another",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
fix timecode strictness.
E.g.
01:02:03,123456 won't be valid, only 01:02:03,123 will be valid. Timecode has to end with \n or $